### PR TITLE
update output Mr (don't subtract Mr at inner boundary)

### DIFF
--- a/src/eruption/hydro/eruption.f
+++ b/src/eruption/hydro/eruption.f
@@ -168,8 +168,9 @@ c      print *,e(3)
       write(*,'(''total energy ='',1pe12.4,''erg, etherm =''
      $     ,e12.4,'' erg'')')te, tet
 
-      write(*,66)(j,encm(j)/msol,rad(j),1.d0/tau(j),p(j),u(j),e(j)
-     &            ,temp(j),j=max(1,jw-10),max(10,min(jw+10,n)))
+      write(*,66)(j,(encm(j)+tmns)/msol,rad(j),1.d0/tau(j),
+     &            p(j),u(j),e(j),temp(j),
+     &            j=max(1,jw-10),max(10,min(jw+10,n)))
  66    format(' no.',4x,'mr',4x,'rad',8x,'rho',6x,'p',5x,'vel'
      &       ,8x,'e',8x,'temp',/,(i4,1p7e9.2))
 
@@ -382,14 +383,16 @@ c      write(*,*)"timetocc=",time_to_cc
              write(*,'(5h no.  ,8h  mr    ,9hradius   ,   9hdensity  ,
      $          9hpressure ,9hvelocity ,9h     e   ,9h temp    ,
      $          9h    L   ,/,(i5,1p8e9.2))')
-     $          (j,encm(j)/msol,rad(j),1.d0/tau(j),ps(j),us(j),e(j)
-     $          ,temp(j),lum(j),j=max(3,jw-10),max(10,min(jw+10,n)))
+     $          (j,(encm(j)+tmns)/msol,rad(j),1.d0/tau(j),
+     $           ps(j),us(j),e(j),temp(j),lum(j),
+     $           j=max(3,jw-10),max(10,min(jw+10,n)))
              write(*,*) "------------------------"
              write(*,'(5h no.  ,8h  mr    ,9hradius   ,   9hdensity  ,
      $          9hpressure ,9hvelocity ,9h     e   ,9h temp    ,
      $          9h    L   ,/,(i5,1p8e9.2))')
-     $          (j,encm(j)/msol,rad(j),1.d0/tau(j),ps(j),us(j),e(j)
-     $          ,temp(j),lum(j),j=n-4,n)
+     $          (j,(encm(j)+tmns)/msol,rad(j),1.d0/tau(j),
+     $           ps(j),us(j),e(j),temp(j),lum(j),
+     $           j=n-4,n)
            end if
 
            ! after cutting innermost region at late times
@@ -397,15 +400,16 @@ c      write(*,*)"timetocc=",time_to_cc
              write(*,'(5h no.  ,8h  mr    ,9hradius   ,   9hdensity  ,
      $          9hpressure ,9hvelocity ,9h     e   ,9h temp    ,
      $          9h    u   ,/,(i5,1p8e9.2))')
-     $          (j,encm(j)/msol,rad(j),1.d0/tau(j),ps(j),us(j),e(j)
-     $          ,temp(j),u(j),
-     $          j=max(fixedCell,jw-10),max(10+fixedCell,min(jw+10,n)))
+     $          (j,(encm(j)+tmns)/msol,rad(j),1.d0/tau(j),
+     $           ps(j),us(j),e(j),temp(j),u(j),
+     $           j=max(fixedCell,jw-10),max(10+fixedCell,min(jw+10,n)))
              write(*,*) "------------------------"
              write(*,'(5h no.  ,8h  mr    ,9hradius   ,   9hdensity  ,
      $          9hpressure ,9hvelocity ,9h     e   ,9h temp    ,
      $          9h    u   ,/,(i5,1p8e9.2))')
-     $          (j,encm(j)/msol,rad(j),1.d0/tau(j),ps(j),us(j),e(j)
-     $          ,temp(j),u(j),j=n-4,n)
+     $          (j,(encm(j)+tmns)/msol,rad(j),1.d0/tau(j),
+     $           ps(j),us(j),e(j),temp(j),u(j),
+     $           j=n-4,n)
            end if
          end if
 


### PR DESCRIPTION
The standard output showed Mr=0 at the innermost cell, which had confused some people as this value is the mass coordinate from the inner boundary of the simulation (and not from the star's center). This commit updates the standard output to show the Mr measured from the center.
A first timestep output (for the 15Msun RSG calculation in README) is now like shown below.

```
 time =   8.4849E+02 sec dt =   8.4849E+02 sec step        0
total energy = -3.6148E+47erg, etherm =  8.6099E+47 erg
 no.   mr    radius   density  pressure velocity      e    temp        L   ,
    3 5.15E+00 1.71E+12 8.24E-06 1.23E+09 0.00E+00-7.93E+13 6.71E+05-1.97E+40
    4 5.16E+00 1.73E+12 1.60E-05 1.16E+09-7.12E+04 1.15E+15 1.28E+06 1.15E+40
    5 5.16E+00 1.76E+12 7.76E-06 1.10E+09-1.17E+05 1.15E+15 1.08E+06 3.82E+38
```